### PR TITLE
Add version, default to 'dev'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,9 @@ var (
 	}
 )
 
-func Execute() error {
-	return rootCmd.Execute()
+func Factory(version string) *cobra.Command {
+	rootCmd.Version = version
+	return rootCmd
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -7,8 +7,11 @@ import (
 	"github.com/swinton/device-flow/cmd"
 )
 
+var version = "dev"
+
 func main() {
-	if err := cmd.Execute(); err != nil {
+	rootCmd := cmd.Factory(version)
+	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Should get overridden by GoReleaser, see: https://goreleaser.com/cookbooks/using-main.version/